### PR TITLE
Fix: p2p port binding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847
 	github.com/aws/aws-sdk-go v1.25.48
 	github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6
+	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5
 	github.com/cespare/cp v0.1.0
 	github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6 h1:Eey/GGQ/E5Xp1P2Lyx1qj007hLZfbi0+CoVeJruGCtI=
 github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6/go.mod h1:Dmm/EzmjnCiweXmzRIAiUWCInVmPgjkzgv5k4tVyXiQ=
+github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5 h1:BjkPE3785EwPhhyuFkbINB+2a1xATwk8SNDWnJiD41g=
+github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5/go.mod h1:jtAfVaU/2cu1+wdSRPWE2c1N2qeAA3K4RH9pYgqwets=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -76,6 +76,7 @@ var (
 	errSelf             = errors.New("is self")
 	errAlreadyDialing   = errors.New("already dialing")
 	errAlreadyConnected = errors.New("already connected")
+	errAlreadyListened  = errors.New("already listened")
 	errRecentlyDialed   = errors.New("recently dialed")
 	errNotWhitelisted   = errors.New("not contained in netrestrict whitelist")
 	errNoPort           = errors.New("node does not provide TCP port")

--- a/p2p/netutil/netstat.go
+++ b/p2p/netutil/netstat.go
@@ -4,15 +4,13 @@ import (
 	"github.com/cakturk/go-netstat/netstat"
 )
 
-func PortListeners(port int) (processes map[int]string, err error) {
+func UdpPortListeners(port int) (processes map[int]string, err error) {
 	var binds []netstat.SockTabEntry
 	processes = make(map[int]string)
 
 	for _, socks := range []func(netstat.AcceptFn) ([]netstat.SockTabEntry, error){
 		netstat.UDPSocks,
 		netstat.UDP6Socks,
-		netstat.TCPSocks,
-		netstat.TCP6Socks,
 	} {
 		binds, err = socks(func(se *netstat.SockTabEntry) bool {
 			return int(se.LocalAddr.Port) == port

--- a/p2p/netutil/netstat.go
+++ b/p2p/netutil/netstat.go
@@ -1,0 +1,29 @@
+package netutil
+
+import (
+	"github.com/cakturk/go-netstat/netstat"
+)
+
+func PortListeners(port int) (processes map[int]string, err error) {
+	var binds []netstat.SockTabEntry
+	processes = make(map[int]string)
+
+	for _, socks := range []func(netstat.AcceptFn) ([]netstat.SockTabEntry, error){
+		netstat.UDPSocks,
+		netstat.UDP6Socks,
+		netstat.TCPSocks,
+		netstat.TCP6Socks,
+	} {
+		binds, err = socks(func(se *netstat.SockTabEntry) bool {
+			return int(se.LocalAddr.Port) == port
+		})
+		if err != nil {
+			return
+		}
+
+		for _, listener := range binds {
+			processes[listener.Process.Pid] = listener.Process.Name
+		}
+	}
+	return
+}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -554,6 +554,17 @@ func (srv *Server) setupDiscovery() error {
 	if err != nil {
 		return err
 	}
+
+	listeners, err := netutil.PortListeners(addr.Port)
+	if err != nil {
+		return err
+	}
+	if len(listeners) > 0 {
+		err = errAlreadyListened
+		srv.log.Error("Port", "addr", addr, "err", err, "listeners", listeners)
+		return err
+	}
+
 	conn, err := net.ListenUDP("udp", addr)
 	if err != nil {
 		return err

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -555,13 +555,13 @@ func (srv *Server) setupDiscovery() error {
 		return err
 	}
 
-	listeners, err := netutil.PortListeners(addr.Port)
+	listeners, err := netutil.UdpPortListeners(addr.Port)
 	if err != nil {
 		return err
 	}
 	if len(listeners) > 0 {
 		err = errAlreadyListened
-		srv.log.Error("Port", "addr", addr, "err", err, "listeners", listeners)
+		srv.log.Error("UDP port", "addr", addr, "err", err, "listeners", listeners)
 		return err
 	}
 


### PR DESCRIPTION
Normally p2p server fails if p2p port is busy by other listener. This case is easy to notice and fix.
But sometimes other listener binds to UDP port with SO_REUSEPORT option (Window's "Connected Devices Platform" service as example), then p2p server can bind to that port without any error but doesn't receive data from. Such case is difficult to recognize.

The way to figure out port is busy is ask OS for list of port listeners, like netstat do.