### PR TITLE
netstat nop

### DIFF
--- a/p2p/netutil/netstat.go
+++ b/p2p/netutil/netstat.go
@@ -1,3 +1,5 @@
+// +build linux windows
+
 package netutil
 
 import (

--- a/p2p/netutil/netstat_nop.go
+++ b/p2p/netutil/netstat_nop.go
@@ -1,0 +1,9 @@
+// +build !linux,!windows
+
+package netutil
+
+func UdpPortListeners(port int) (processes map[int]string, err error) {
+	processes = make(map[int]string)
+
+	return
+}


### PR DESCRIPTION
UdpPortListeners() stub as alternative for non linux and non windows OS since "github.com/cakturk/go-netstat/netstat" is implemented only for linux or windows.