### PR TITLE
Block header hash refactor

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -84,7 +84,7 @@ type Header struct {
 	Nonce       BlockNonce     `json:"nonce"`
 
 	// caches
-	hash atomic.Value `rlp:"-"`
+	externalHash atomic.Value `rlp:"-"`
 }
 
 // field type overrides for gencodec
@@ -100,16 +100,19 @@ type headerMarshaling struct {
 
 // Hash returns the block hash of the header, which is simply the keccak256 hash of its
 // RLP encoding.
+// Also hash of the header could be overridden with external value.
 func (h *Header) Hash() common.Hash {
-	cached := h.hash.Load()
-	if cached != nil {
-		return cached.(common.Hash)
+	external := h.externalHash.Load()
+	if external != nil {
+		return external.(common.Hash)
 	}
+
 	return rlpHash(h)
 }
 
-func (h *Header) SetHashCache(hash common.Hash) {
-	h.hash.Store(hash)
+// SetExternalHash overrides hash with external value.
+func (h *Header) SetExternalHash(hash common.Hash) {
+	h.externalHash.Store(hash)
 }
 
 var headerSize = common.StorageSize(reflect.TypeOf(Header{}).Size())
@@ -164,7 +167,6 @@ type Block struct {
 	transactions Transactions
 
 	// caches
-	hash atomic.Value
 	size atomic.Value
 
 	// Td is used by package core to store the total difficulty
@@ -363,31 +365,9 @@ func (b *Block) WithBody(transactions []*Transaction, uncles []*Header) *Block {
 	return block
 }
 
-// WithHash returns a new block with the custom hash.
-func (b *Block) WithHash(h common.Hash) *Block {
-	block := &Block{
-		header:       CopyHeader(b.header),
-		transactions: make([]*Transaction, len(b.transactions)),
-		uncles:       make([]*Header, len(b.uncles)),
-	}
-	copy(block.transactions, b.transactions)
-	for i, uncle := range b.uncles {
-		block.uncles[i] = CopyHeader(uncle)
-	}
-
-	block.hash.Store(h)
-	return block
-}
-
 // Hash returns the keccak256 hash of b's header.
-// The hash is computed on the first call and cached thereafter.
 func (b *Block) Hash() common.Hash {
-	if hash := b.hash.Load(); hash != nil {
-		return hash.(common.Hash)
-	}
-	v := b.header.Hash()
-	b.hash.Store(v)
-	return v
+	return b.header.Hash()
 }
 
 type Blocks []*Block

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -246,6 +246,13 @@ func CopyHeader(h *Header) *Header {
 		cpy.Extra = make([]byte, len(h.Extra))
 		copy(cpy.Extra, h.Extra)
 	}
+
+	external := h.externalHash.Load()
+	if external != nil {
+		hash := external.(common.Hash)
+		cpy.SetExternalHash(hash)
+	}
+
 	return &cpy
 }
 

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -163,9 +163,10 @@ func (ec *Client) getBlock(ctx context.Context, method string, args ...interface
 		txs[i] = tx.tx
 	}
 
+	head.SetExternalHash(body.Hash)
 	block := types.NewBlockWithHeader(head).
-		WithBody(txs, uncles).
-		WithHash(body.Hash)
+		WithBody(txs, uncles)
+
 	return block, nil
 }
 


### PR DESCRIPTION
More clear code.
New Header.SetExternalHash() method.