### PR TITLE
snap.BlockChain interface instead of *core.BlockChain

### DIFF
--- a/eth/handler_snap.go
+++ b/eth/handler_snap.go
@@ -17,7 +17,6 @@
 package eth
 
 import (
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
@@ -26,7 +25,7 @@ import (
 // packets that are sent as replies or broadcasts.
 type snapHandler handler
 
-func (h *snapHandler) Chain() *core.BlockChain { return h.chain }
+func (h *snapHandler) Chain() snap.BlockChain { return h.chain }
 
 // RunPeer is invoked when a peer joins on the `snap` protocol.
 func (h *snapHandler) RunPeer(peer *snap.Peer, hand snap.Handler) error {

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/light"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
@@ -61,11 +61,21 @@ const (
 // exchanges have passed.
 type Handler func(peer *Peer) error
 
+type BlockChain interface {
+	// StateCache returns the caching database underpinning the blockchain instance.
+	StateCache() state.Database
+	// ContractCode retrieves a blob of data associated with a contract hash
+	// either from ephemeral in-memory cache, or from persistent storage.
+	ContractCode(hash common.Hash) ([]byte, error)
+	// Snapshots returns the blockchain snapshot tree.
+	Snapshots() *snapshot.Tree
+}
+
 // Backend defines the data retrieval methods to serve remote requests and the
 // callback methods to invoke on remote deliveries.
 type Backend interface {
 	// Chain retrieves the blockchain object to serve data.
-	Chain() *core.BlockChain
+	Chain() BlockChain
 
 	// RunPeer is invoked when a peer joins on the `eth` protocol. The handler
 	// should do any peer maintenance work, handshakes and validations. If all
@@ -523,6 +533,6 @@ func handleMessage(backend Backend, peer *Peer) error {
 type NodeInfo struct{}
 
 // nodeInfo retrieves some `snap` protocol metadata about the running host node.
-func nodeInfo(chain *core.BlockChain) *NodeInfo {
+func nodeInfo(BlockChain) *NodeInfo {
 	return &NodeInfo{}
 }


### PR DESCRIPTION
Makes possible to untie snaps protocol handler from ethereum blockchain implementation.