### PR TITLE
Update snap ProtocolName

### DIFF
--- a/eth/protocols/snap/protocol.go
+++ b/eth/protocols/snap/protocol.go
@@ -32,7 +32,7 @@ const (
 
 // ProtocolName is the official short name of the `snap` protocol used during
 // devp2p capability negotiation.
-const ProtocolName = "snap"
+const ProtocolName = "fsnap"
 
 // ProtocolVersions are the supported versions of the `snap` protocol (first
 // is primary).


### PR DESCRIPTION
This PR updates `snap.ProtocolName` to `fsnap`. 