### PR TITLE
trie: prunning old state trie node on disk

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -592,6 +592,7 @@ func (db *Database) dereference(batch ethdb.KeyValueWriter, child common.Hash, p
 			db.dereference(batch, hash, child)
 		})
 		if db.dirties[child].commited {
+			log.Info("delete trie node", "hash", child)
 			rawdb.DeleteTrieNode(batch, child)
 		}
 		delete(db.dirties, child)

--- a/trie/database.go
+++ b/trie/database.go
@@ -187,9 +187,6 @@ func (n *cachedNode) obj(hash common.Hash) node {
 // both the implicit ones from inside the node as well as the explicit ones
 // from outside the node.
 func (n *cachedNode) forChilds(onChild func(hash common.Hash)) {
-	if n == nil {
-		return
-	}
 	for child := range n.children {
 		onChild(child)
 	}
@@ -306,9 +303,8 @@ func NewDatabaseWithConfig(diskdb ethdb.KeyValueStore, config *Config) *Database
 		}
 	}
 	db := &Database{
-		diskdb:   diskdb,
-		greedyGC: false,
-		cleans:   cleans,
+		diskdb: diskdb,
+		cleans: cleans,
 		dirties: map[common.Hash]*cachedNode{{}: {
 			children: make(map[common.Hash]uint16),
 		}},
@@ -343,7 +339,6 @@ func (db *Database) insert(hash common.Hash, size int, node node) {
 		node:      simplifyNode(node),
 		size:      uint16(size),
 		flushPrev: db.newest,
-		commited:  false,
 	}
 	entry.forChilds(func(child common.Hash) {
 		if c := db.dirties[child]; c != nil {

--- a/trie/database.go
+++ b/trie/database.go
@@ -350,6 +350,7 @@ func (db *Database) insert(hash common.Hash, size int, node node) {
 			c.parents++
 		}
 	})
+	log.Info("insert new trie node into db.dirties", "hash", hash)
 	db.dirties[hash] = entry
 
 	// Update the flush-list endpoints

--- a/trie/database.go
+++ b/trie/database.go
@@ -877,8 +877,7 @@ func (g *greedy) Put(key []byte, rlp []byte) error {
 		return nil
 	}
 	// Mark node as commited if node does not existing on db
-	blob := rawdb.ReadTrieNode(g.db.diskdb, hash)
-	if len(blob) == 0 {
+	if exist, _ := g.db.diskdb.Has(hash[:]); !exist {
 		g.db.dirties[hash].commited = true
 	}
 	return nil

--- a/trie/database.go
+++ b/trie/database.go
@@ -882,6 +882,11 @@ func (g *greedy) Put(key []byte, rlp []byte) error {
 	if exist, _ := g.db.diskdb.Has(hash[:]); !exist {
 		g.db.dirties[hash].commited = true
 	}
+	// Move the flushed node into the clean cache to prevent insta-reloads
+	if g.db.cleans != nil {
+		g.db.cleans.Set(hash[:], rlp)
+		memcacheCleanWriteMeter.Mark(int64(len(rlp)))
+	}
 	return nil
 }
 

--- a/trie/database.go
+++ b/trie/database.go
@@ -677,7 +677,9 @@ func (db *Database) Cap(limit common.StorageSize) error {
 		// delete(db.dirties, db.oldest)
 		// TODO: if we don't delete the dirty nodes here then it will break the cap limit size rule
 		// temporarily to mark the dirty node is commited only
-		db.dirties[db.oldest].committed = true
+		if db.dirties[db.oldest] != nil {
+			db.dirties[db.oldest].committed = true
+		}
 		db.oldest = node.flushNext
 
 		db.dirtiesSize -= common.StorageSize(common.HashLength + int(node.size))
@@ -798,7 +800,9 @@ func (db *Database) commit(hash common.Hash, batch ethdb.Batch, uncacher *cleane
 		batch.Reset()
 		db.lock.Unlock()
 	}
-	db.dirties[hash].committed = true
+	if db.dirties[hash] != nil {
+		db.dirties[hash].committed = true
+	}
 	return nil
 }
 

--- a/trie/database.go
+++ b/trie/database.go
@@ -555,8 +555,15 @@ func (db *Database) dereference(batch ethdb.KeyValueWriter, child common.Hash, p
 		}
 	}
 	// If the child does not exist, it's a previously committed node.
+	// Delete the node on disk if it be marked as well
 	node, ok := db.dirties[child]
 	if !ok {
+		committed, ok := db.commits[child]
+		if ok && committed {
+			// node is commited to the disk already, need to delete it on disk also
+			rawdb.DeleteTrieNode(batch, child)
+		}
+		delete(db.commits, child)
 		return
 	}
 	// If there are no more references to the child, delete it and cascade

--- a/trie/database.go
+++ b/trie/database.go
@@ -648,7 +648,9 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	for size > limit && oldest != (common.Hash{}) {
 		// Fetch the oldest referenced node and push into the batch
 		node := db.dirties[oldest]
-		rawdb.WriteTrieNode(batch, oldest, node.rlp())
+		if !node.commited {
+			rawdb.WriteTrieNode(batch, oldest, node.rlp())
+		}
 
 		// If we exceeded the ideal batch size, commit and reset
 		if batch.ValueSize() >= ethdb.IdealBatchSize {
@@ -799,7 +801,9 @@ func (db *Database) commit(hash common.Hash, batch ethdb.Batch, uncacher ethdb.K
 		return err
 	}
 	// If we've reached an optimal batch size, commit and start over
-	rawdb.WriteTrieNode(batch, hash, node.rlp())
+	if !node.commited {
+		rawdb.WriteTrieNode(batch, hash, node.rlp())
+	}
 	if callback != nil {
 		callback(hash)
 	}

--- a/trie/database.go
+++ b/trie/database.go
@@ -185,6 +185,9 @@ func (n *cachedNode) obj(hash common.Hash) node {
 // both the implicit ones from inside the node as well as the explicit ones
 // from outside the node.
 func (n *cachedNode) forChilds(onChild func(hash common.Hash)) {
+	if n == nil {
+		return
+	}
 	for child := range n.children {
 		onChild(child)
 	}

--- a/trie/database.go
+++ b/trie/database.go
@@ -674,12 +674,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	}
 	for db.oldest != oldest {
 		node := db.dirties[db.oldest]
-		// delete(db.dirties, db.oldest)
-		// TODO: if we don't delete the dirty nodes here then it will break the cap limit size rule
-		// temporarily to mark the dirty node is commited only
-		if db.dirties[db.oldest] != nil {
-			db.dirties[db.oldest].committed = true
-		}
+		delete(db.dirties, db.oldest)
 		db.oldest = node.flushNext
 
 		db.dirtiesSize -= common.StorageSize(common.HashLength + int(node.size))

--- a/trie/database.go
+++ b/trie/database.go
@@ -350,7 +350,7 @@ func (db *Database) insert(hash common.Hash, size int, node node) {
 			c.parents++
 		}
 	})
-	log.Info("insert new trie node into db.dirties", "hash", hash)
+	log.Trace("insert new trie node into db.dirties", "hash", hash)
 	db.dirties[hash] = entry
 
 	// Update the flush-list endpoints
@@ -597,7 +597,7 @@ func (db *Database) dereference(batch ethdb.KeyValueWriter, child common.Hash, p
 			db.dereference(batch, hash, child)
 		})
 		if db.dirties[child].commited {
-			log.Info("delete trie node", "hash", child)
+			log.Warn("delete trie node", "hash", child)
 			rawdb.DeleteTrieNode(batch, child)
 		}
 		delete(db.dirties, child)

--- a/trie/database.go
+++ b/trie/database.go
@@ -626,7 +626,7 @@ func (db *Database) delete(batch ethdb.KeyValueWriter, child common.Hash, parent
 		})
 		rawdb.DeleteTrieNode(batch, child)
 		delete(db.commits, child)
-		log.Info("delete trie node on disk by hash", "hash", child)
+		log.Debug("delete trie node on disk by hash", "hash", child)
 	}
 }
 
@@ -832,7 +832,7 @@ func (db *Database) commit(hash common.Hash, batch ethdb.Batch, uncacher *cleane
 }
 
 func (db *Database) MarkCommit(hash common.Hash) {
-	log.Info("mark node as commited node", "hash", hash)
+	log.Debug("mark node as commited node", "hash", hash)
 	db.commits[hash] = db.dirties[hash]
 }
 

--- a/trie/database.go
+++ b/trie/database.go
@@ -784,9 +784,9 @@ func (db *Database) Commit(node common.Hash, report bool, callback func(common.H
 
 // commit is the private locked version of Commit.
 func (db *Database) commit(hash common.Hash, batch ethdb.Batch, uncacher ethdb.KeyValueWriter, callback func(common.Hash)) error {
-	// If the node does not exist, it's a previously committed node
+	// If the node does not exist or marked as committed, then it's a previously committed node
 	node, ok := db.dirties[hash]
-	if !ok {
+	if !ok || node.commited {
 		return nil
 	}
 	var err error
@@ -799,9 +799,7 @@ func (db *Database) commit(hash common.Hash, batch ethdb.Batch, uncacher ethdb.K
 		return err
 	}
 	// If we've reached an optimal batch size, commit and start over
-	if !node.commited {
-		rawdb.WriteTrieNode(batch, hash, node.rlp())
-	}
+	rawdb.WriteTrieNode(batch, hash, node.rlp())
 	if callback != nil {
 		callback(hash)
 	}

--- a/trie/database.go
+++ b/trie/database.go
@@ -350,7 +350,6 @@ func (db *Database) insert(hash common.Hash, size int, node node) {
 			c.parents++
 		}
 	})
-	log.Trace("insert new trie node into db.dirties", "hash", hash)
 	db.dirties[hash] = entry
 
 	// Update the flush-list endpoints
@@ -597,7 +596,6 @@ func (db *Database) dereference(batch ethdb.KeyValueWriter, child common.Hash, p
 			db.dereference(batch, hash, child)
 		})
 		if db.dirties[child].commited {
-			log.Warn("delete trie node", "hash", child)
 			rawdb.DeleteTrieNode(batch, child)
 		}
 		delete(db.dirties, child)

--- a/trie/database.go
+++ b/trie/database.go
@@ -836,7 +836,7 @@ func (c *cleaner) Put(key []byte, rlp []byte) error {
 			c.db.dirties[node.flushNext].flushPrev = node.flushPrev
 		}
 	}
-	// Mark the node from in the dirty cache as committed
+	// Mark the node in the dirty cache as committed
 	c.db.dirties[hash].commited = true
 	c.db.dirtiesSize -= common.StorageSize(common.HashLength + int(node.size))
 	if node.children != nil {

--- a/trie/database.go
+++ b/trie/database.go
@@ -587,8 +587,10 @@ func (db *Database) dereference(batch ethdb.KeyValueWriter, child common.Hash, p
 		node.forChilds(func(hash common.Hash) {
 			db.dereference(batch, hash, child)
 		})
+		if db.dirties[child].commited {
+			rawdb.DeleteTrieNode(batch, child)
+		}
 		delete(db.dirties, child)
-		rawdb.DeleteTrieNode(batch, child)
 		db.dirtiesSize -= common.StorageSize(common.HashLength + int(node.size))
 		if node.children != nil {
 			db.childrenSize -= cachedNodeChildrenSize

--- a/trie/database.go
+++ b/trie/database.go
@@ -608,6 +608,7 @@ func (db *Database) delete(batch ethdb.KeyValueWriter, child common.Hash) {
 	})
 	rawdb.DeleteTrieNode(batch, child)
 	delete(db.commits, child)
+	log.Info("delete trie node on disk by hash", "hash", child)
 }
 
 // Cap iteratively flushes old but still referenced trie nodes until the total
@@ -812,6 +813,7 @@ func (db *Database) commit(hash common.Hash, batch ethdb.Batch, uncacher *cleane
 }
 
 func (db *Database) MarkCommit(hash common.Hash) {
+	log.Info("mark node as commited node", "hash", hash)
 	db.commits[hash] = db.dirties[hash]
 }
 

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -105,7 +105,7 @@ func (t *Trie) NodeIterator(start []byte) NodeIterator {
 func (t *Trie) Get(key []byte) []byte {
 	res, err := t.TryGet(key)
 	if err != nil {
-		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
+		log.Error(fmt.Sprintf("Get Unhandled trie error: %v", err))
 	}
 	return res
 }
@@ -117,6 +117,9 @@ func (t *Trie) TryGet(key []byte) ([]byte, error) {
 	value, newroot, didResolve, err := t.tryGet(t.root, keybytesToHex(key), 0)
 	if err == nil && didResolve {
 		t.root = newroot
+	}
+	if err != nil {
+		log.Error(fmt.Sprintf("TryGet Unhandled trie error: %v", err))
 	}
 	return value, err
 }
@@ -162,6 +165,7 @@ func (t *Trie) tryGet(origNode node, key []byte, pos int) (value []byte, newnode
 func (t *Trie) TryGetNode(path []byte) ([]byte, int, error) {
 	item, newroot, resolved, err := t.tryGetNode(t.root, compactToHex(path), 0)
 	if err != nil {
+		log.Error(fmt.Sprintf("TryGetNode Unhandled trie error: %v", err))
 		return nil, resolved, err
 	}
 	if resolved > 0 {
@@ -242,7 +246,7 @@ func (t *Trie) tryGetNode(origNode node, path []byte, pos int) (item []byte, new
 // stored in the trie.
 func (t *Trie) Update(key, value []byte) {
 	if err := t.TryUpdate(key, value); err != nil {
-		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
+		log.Error(fmt.Sprintf("Update Unhandled trie error: %v", err))
 	}
 }
 
@@ -260,12 +264,14 @@ func (t *Trie) TryUpdate(key, value []byte) error {
 	if len(value) != 0 {
 		_, n, err := t.insert(t.root, nil, k, valueNode(value))
 		if err != nil {
+			log.Error(fmt.Sprintf("TryUpdate (insert) Unhandled trie error: %v", err))
 			return err
 		}
 		t.root = n
 	} else {
 		_, n, err := t.delete(t.root, nil, k)
 		if err != nil {
+			log.Error(fmt.Sprintf("TryUpdate (delete) Unhandled trie error: %v", err))
 			return err
 		}
 		t.root = n
@@ -345,7 +351,7 @@ func (t *Trie) insert(n node, prefix, key []byte, value node) (bool, node, error
 // Delete removes any existing value for key from the trie.
 func (t *Trie) Delete(key []byte) {
 	if err := t.TryDelete(key); err != nil {
-		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
+		log.Error(fmt.Sprintf("Delete Unhandled trie error: %v", err))
 	}
 }
 
@@ -356,6 +362,7 @@ func (t *Trie) TryDelete(key []byte) error {
 	k := keybytesToHex(key)
 	_, n, err := t.delete(t.root, nil, k)
 	if err != nil {
+		log.Error(fmt.Sprintf("TryDelete Unhandled trie error: %v", err))
 		return err
 	}
 	t.root = n

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -105,7 +105,7 @@ func (t *Trie) NodeIterator(start []byte) NodeIterator {
 func (t *Trie) Get(key []byte) []byte {
 	res, err := t.TryGet(key)
 	if err != nil {
-		log.Error(fmt.Sprintf("Get Unhandled trie error: %v", err))
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 	}
 	return res
 }
@@ -119,7 +119,7 @@ func (t *Trie) TryGet(key []byte) ([]byte, error) {
 		t.root = newroot
 	}
 	if err != nil {
-		log.Error(fmt.Sprintf("TryGet Unhandled trie error: %v", err))
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 	}
 	return value, err
 }
@@ -165,7 +165,7 @@ func (t *Trie) tryGet(origNode node, key []byte, pos int) (value []byte, newnode
 func (t *Trie) TryGetNode(path []byte) ([]byte, int, error) {
 	item, newroot, resolved, err := t.tryGetNode(t.root, compactToHex(path), 0)
 	if err != nil {
-		log.Error(fmt.Sprintf("TryGetNode Unhandled trie error: %v", err))
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 		return nil, resolved, err
 	}
 	if resolved > 0 {
@@ -246,7 +246,7 @@ func (t *Trie) tryGetNode(origNode node, path []byte, pos int) (item []byte, new
 // stored in the trie.
 func (t *Trie) Update(key, value []byte) {
 	if err := t.TryUpdate(key, value); err != nil {
-		log.Error(fmt.Sprintf("Update Unhandled trie error: %v", err))
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 	}
 }
 
@@ -264,14 +264,14 @@ func (t *Trie) TryUpdate(key, value []byte) error {
 	if len(value) != 0 {
 		_, n, err := t.insert(t.root, nil, k, valueNode(value))
 		if err != nil {
-			log.Error(fmt.Sprintf("TryUpdate (insert) Unhandled trie error: %v", err))
+			log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 			return err
 		}
 		t.root = n
 	} else {
 		_, n, err := t.delete(t.root, nil, k)
 		if err != nil {
-			log.Error(fmt.Sprintf("TryUpdate (delete) Unhandled trie error: %v", err))
+			log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 			return err
 		}
 		t.root = n
@@ -351,7 +351,7 @@ func (t *Trie) insert(n node, prefix, key []byte, value node) (bool, node, error
 // Delete removes any existing value for key from the trie.
 func (t *Trie) Delete(key []byte) {
 	if err := t.TryDelete(key); err != nil {
-		log.Error(fmt.Sprintf("Delete Unhandled trie error: %v", err))
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 	}
 }
 
@@ -362,7 +362,7 @@ func (t *Trie) TryDelete(key []byte) error {
 	k := keybytesToHex(key)
 	_, n, err := t.delete(t.root, nil, k)
 	if err != nil {
-		log.Error(fmt.Sprintf("TryDelete Unhandled trie error: %v", err))
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 		return err
 	}
 	t.root = n

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -118,9 +118,6 @@ func (t *Trie) TryGet(key []byte) ([]byte, error) {
 	if err == nil && didResolve {
 		t.root = newroot
 	}
-	if err != nil {
-		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
-	}
 	return value, err
 }
 
@@ -165,7 +162,6 @@ func (t *Trie) tryGet(origNode node, key []byte, pos int) (value []byte, newnode
 func (t *Trie) TryGetNode(path []byte) ([]byte, int, error) {
 	item, newroot, resolved, err := t.tryGetNode(t.root, compactToHex(path), 0)
 	if err != nil {
-		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 		return nil, resolved, err
 	}
 	if resolved > 0 {
@@ -264,14 +260,12 @@ func (t *Trie) TryUpdate(key, value []byte) error {
 	if len(value) != 0 {
 		_, n, err := t.insert(t.root, nil, k, valueNode(value))
 		if err != nil {
-			log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 			return err
 		}
 		t.root = n
 	} else {
 		_, n, err := t.delete(t.root, nil, k)
 		if err != nil {
-			log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 			return err
 		}
 		t.root = n
@@ -362,7 +356,6 @@ func (t *Trie) TryDelete(key []byte) error {
 	k := keybytesToHex(key)
 	_, n, err := t.delete(t.root, nil, k)
 	if err != nil {
-		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 		return err
 	}
 	t.root = n


### PR DESCRIPTION
Original geth GC is based on avoiding writing nodes which which were dereferenced earlier than there was a need to commit them on disk. Yet, Opera commits data on disk more often due to the usage of flushable DB wrapper, which get filled with relatively often. As a result, the original GC doesn't garbage collect the most of nodes
This PR adds an option to enable the greedy GC mode which not only avoids writing nodes derefernced nodes, but also erases dereferenced nodes from disk if they were committed earlier