### PR TITLE
eth/protocols/snap: avoid estimating infinite percentage

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -2798,6 +2798,11 @@ func (s *Syncer) reportSyncProgress(force bool) {
 		accountFills,
 	).Uint64())
 
+	// Don't report anything until we have a meaningful progress
+	if estBytes < 1.0 {
+		return
+	}
+
 	elapsed := time.Since(s.startTime)
 	estTime := elapsed / time.Duration(synced) * time.Duration(estBytes)
 


### PR DESCRIPTION
Port code to fix a small issue of snapsync progress report as `synced=+Inf%` when `estBytes == 0`

```
INFO [03-03|17:00:57.754] State sync in progress                   synced=+Inf% state=325.02KiB accounts=0@0.00B slots=1573@325.02KiB codes=0@0.00B eta=-315.414ms
```