### PR TITLE
Set RPC call timeout to 5 minutes

### DIFF
--- a/rpc/service.go
+++ b/rpc/service.go
@@ -183,7 +183,7 @@ func (c *callback) makeArgTypes() {
 
 // call invokes the callback.
 func (c *callback) call(ctx context.Context, method string, args []reflect.Value) (res interface{}, errRes error) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
 	// Create the argument slice.


### PR DESCRIPTION
In PR #32 have been introduced 5-seconds timeout for any RPC request. This resolves the opened iterators performance issue, but prevents running a lot of valid requests. The 5-minutes timeout is the value we currently use on RPC API and it proved to be sufficient to resolve the performance issue without affecting valid queries.