### PR TITLE
Add possibility to configure RPC execution time limit

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -28,6 +28,15 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+var (
+	executionTimeLimit = 5 * time.Second
+)
+
+// SetExecutionTimeLimit sets execution limit for RPC method calls
+func SetExecutionTimeLimit(limit time.Duration) {
+	executionTimeLimit = limit
+}
+
 // handler handles JSON-RPC messages. There is one handler per connection. Note that
 // handler is not safe for concurrent use. Message handling never blocks indefinitely
 // because RPCs are processed on background goroutines launched by handler.
@@ -334,7 +343,11 @@ func (h *handler) handleCall(cp *callProc, msg *jsonrpcMessage) *jsonrpcMessage 
 		return msg.errorResponse(&invalidParamsError{err.Error()})
 	}
 	start := time.Now()
-	answer := h.runMethod(cp.ctx, msg, callb, args)
+
+	ctx, cancel := context.WithTimeout(cp.ctx, executionTimeLimit)
+	defer cancel()
+
+	answer := h.runMethod(ctx, msg, callb, args)
 
 	// Collect the statistics for RPC calls if metrics is enabled.
 	// We only care about pure rpc call. Filter out subscription.

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -24,7 +24,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"time"
 	"unicode"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -183,9 +182,6 @@ func (c *callback) makeArgTypes() {
 
 // call invokes the callback.
 func (c *callback) call(ctx context.Context, method string, args []reflect.Value) (res interface{}, errRes error) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
 	// Create the argument slice.
 	fullargs := make([]reflect.Value, 0, 2+len(args))
 	if c.rcvr.IsValid() {


### PR DESCRIPTION
Allow to configure timeout for RPC method calls.

Replaces https://github.com/Fantom-foundation/go-ethereum/pull/33 