### PR TITLE
Fix of RPC graceful stop

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -228,9 +228,12 @@ func (h *handler) cancelServerSubscriptions(err error) {
 // startCallProc runs fn in a new goroutine and starts tracking it in the h.calls wait group.
 func (h *handler) startCallProc(fn func(*callProc)) {
 	h.callWG.Add(1)
+	h.reg.callWG.Add(1)
 	go func() {
-		ctx, cancel := context.WithCancel(h.rootCtx)
 		defer h.callWG.Done()
+		defer h.reg.callWG.Done()
+
+		ctx, cancel := context.WithCancel(h.rootCtx)
 		defer cancel()
 		fn(&callProc{ctx: ctx})
 	}()

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -38,6 +38,7 @@ var (
 
 type serviceRegistry struct {
 	mu       sync.Mutex
+	callWG   sync.WaitGroup
 	services map[string]service
 }
 


### PR DESCRIPTION
rpc.Server.Stop() waits all the pending rpc-calls finished to prevent fails
```ERROR[01-25|09:41:54.390] RPC method eth_call crashed: runtime error: invalid memory address or nil pointer dereference```
, when store stop occurs after server stop but rpc-calls still need the store.  

Tested on [go-opera](https://github.com/Fantom-foundation/go-opera/compare/5fb238e01a57...rus-alex:go-opera:fix/api-graceful-stop).