### PR TITLE
Ban bad nodes

### DIFF
--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -69,6 +69,7 @@ const (
 	DiscUnexpectedIdentity
 	DiscSelf
 	DiscReadTimeout
+	DiscBanned
 	DiscSubprotocolError = 0x10
 )
 
@@ -85,6 +86,7 @@ var discReasonToString = [...]string{
 	DiscUnexpectedIdentity:  "unexpected identity",
 	DiscSelf:                "connected to self",
 	DiscReadTimeout:         "read timeout",
+	DiscBanned:              "banned node",
 	DiscSubprotocolError:    "subprotocol error",
 }
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -837,6 +837,7 @@ running:
 func (srv *Server) postHandshakeChecks(peers map[enode.ID]*Peer, inboundCount int, c *conn) error {
 	switch {
 	case discfilter.BannedDynamic(c.node.ID()):
+		// ignore the peer if it is already banned
 		return DiscBanned
 	case !c.is(trustedConn) && len(peers) >= srv.MaxPeers:
 		return DiscTooManyPeers


### PR DESCRIPTION
This PR is to avoid dialling banned nodes during the discovery process.
This fix will avoid bandwidth wastage due to dialling invalid clients repeatedly.

During an hour-long test run on the Mainnet with this PR, 
- About 26K potential invalid dials were discarded because they were banned during handshake previously.
- About 17K Peers were banned because of caps mismatch (eth, eth2 etc)
- About 3K Peer handshakes were rejected because they were banned. 


