### PR TITLE
Fix of prometheus metric's key

### DIFF
--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -19,8 +19,8 @@ package prometheus
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/metrics"
 )
@@ -115,6 +115,16 @@ func (c *collector) writeSummaryPercentile(name, p string, value interface{}) {
 	c.buff.WriteString(fmt.Sprintf(keyQuantileTagValueTpl, name, p, value))
 }
 
+var (
+	keyInvalidCharacters = regexp.MustCompile("[^a-zA-Z0-9_]")
+	digitalPrefix        = regexp.MustCompile("^[0-9].*")
+)
+
 func mutateKey(key string) string {
-	return strings.Replace(key, "/", "_", -1)
+	key = keyInvalidCharacters.ReplaceAllLiteralString(key, "_")
+	if digitalPrefix.MatchString(key) {
+		key = "_" + key
+	}
+
+	return key
 }

--- a/metrics/prometheus/collector_test.go
+++ b/metrics/prometheus/collector_test.go
@@ -108,3 +108,19 @@ test_resetting_timer {quantile="0.99"} 120000000
 		t.Fatal("unexpected collector output")
 	}
 }
+
+func TestKeyMutation(t *testing.T) {
+	for key, exp := range map[string]string{
+		"":                            "",
+		"A":                           "A",
+		"api_http_requests_total":     "api_http_requests_total",
+		"API_http_requests-total":     "API_http_requests_total",
+		"api~http%requests$total/0":   "api_http_requests_total_0",
+		"09api~http%requests$total/0": "_09api_http_requests_total_0",
+	} {
+		got := mutateKey(key)
+		if got != exp {
+			t.Fatalf("Key mutation fail: got '%s' want '%s'", got, exp)
+		}
+	}
+}


### PR DESCRIPTION
Includes `metrics/prometheus.mutateKey()` upgrade to prevent a lot of errors and hotfixes, such as:

- https://github.com/Fantom-foundation/go-opera/pull/418
- https://github.com/Fantom-foundation/go-opera/pull/419
- https://github.com/Fantom-foundation/go-opera/pull/438
- https://github.com/Fantom-foundation/go-opera/pull/450
- https://github.com/Fantom-foundation/go-opera/pull/451